### PR TITLE
Tweak ci script a little, update lib.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.rs.bk
 *.svd
+*.svd.raw
 Cargo.lock
 target/

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,9 +10,11 @@ main() {
         local url=https://github.com/posborne/cmsis-svd/raw/python-0.4/data/$svd
         local td=$(mktemp -d)
         local svd=$(basename $svd)
+        local svdraw=${svd}.raw
         local patch="${svd%.*}.patch"
-        curl -LO $url
-        dos2unix $svd
+        curl -L -o $svdraw $url
+        dos2unix $svdraw
+        cp $svdraw $svd
         patch -p1 $svd < $patch
 
         rm -rf $td


### PR DESCRIPTION
Jorge,

These commits are what was left in my tree for the stm32f103xx code.

The first commit alters the way the SVD is fetched so that it's a little easier to reuse ci/script.sh when trying to develop a fix to the patch.

The second applies svd2rust and rustfmt to update lib.rs  I hand-tweaked the layout of the top of the file to reduce the number of changes  in the face of rustfmt altering purely whitespace at the top; though I left it altering whitespace throughout the rest of the file.

D.
