### PR TITLE
Bump cortex-m-rt version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.3.0"
+version = "0.4.0"
 
 [features]
 rt = ["cortex-m-rt"]


### PR DESCRIPTION
I'm using this crate with `cortex-m-rt` 0.4.0. This currently requires local overrides.

This PR would bump `cortex-m-rt` to 0.4.0 for everyone, which means I can go back to using this crate's upstream version, but also means [the `cortex-m-rt` 0.4.0 caveats](https://github.com/japaric/cortex-m-rt/blob/master/CHANGELOG.md#v040---2018-04-09) apply to everyone. I assume you're happy with that outcome – you did release `cortex-m-rt` 0.4.0 after all – but thought it worth documenting here.